### PR TITLE
Use two manchester devices at 50 MHz clocl

### DIFF
--- a/clock_divider.vhd
+++ b/clock_divider.vhd
@@ -6,15 +6,19 @@ USE IEEE.NUMERIC_STD.ALL;
 ENTITY clock_divider IS
     PORT (
         clock_100MHz    :   IN STD_lOGIC;
+        clock_50MHz : OUT STD_LOGIC ;
         clock_1Hz       :   OUT STD_lOGIC
     );
 END clock_divider;
 
 
 ARCHITECTURE clock_architecture OF clock_divider IS
-    SIGNAL line_1Hz :   STD_LOGIC := '0';
+    SIGNAL line_1Hz :   STD_LOGIC := '0' ;
+    SIGNAL line_50MHz : STD_LOGIC := '0' ;
 BEGIN
-    clock_1Hz <= line_1Hz;
+    clock_1Hz <= line_1Hz ;
+    clock_50MHz <= line_50MHz ;
+   
     
 FREQ_1Hz:       PROCESS(clock_100MHz, line_1Hz)
         VARIABLE count_100000000:   UNSIGNED (25 DOWNTO 0)  := "10111110101111000010000000";  -- 1Hz clock : I have updated this to be a value of 50,000,000 rahter THEN 100,000,000 - Archie [NEW].
@@ -28,5 +32,19 @@ FREQ_1Hz:       PROCESS(clock_100MHz, line_1Hz)
             counter_100000000 := counter_100000000 + 1;
         END IF;
     END PROCESS;
-        
+
+
+FREQ_50MHz: PROCESS(clock_100MHz, line_50MHz)
+        VARIABLE count_50000000 : UNSIGNED(1 DOWNTO 0) := "10" ; 
+        VARIABLE counter_50000000 : UNSIGNED(1 DOWNTO 0) := "00" ;   
+    BEGIN
+        IF RISING_EDGE(clock_100MHz) THEN
+            IF (counter_50000000 = count_50000000) THEN
+                line_50MHz <= not line_50MHz ;
+                counter_50000000 := "00" ;
+            END IF ;
+            counter_50000000 := counter_50000000 + 1 ;
+        END IF ;
+    END PROCESS ;
+    
 END clock_architecture;

--- a/manchester_main.vhd
+++ b/manchester_main.vhd
@@ -14,11 +14,11 @@ ENTITY main IS
     PORT (
         clock:      IN STD_LOGIC;
         reset:      IN STD_LOGIC;
-        --ppm_out:    OUT STD_LOGIC;
-        man_out:    OUT STD_LOGIC
-        ---ppm_in:     IN STD_LOGIC;
-        --man_in:     IN STD_LOGIC
+        clock_sel:  IN STD_LOGIC;
+        man1_out:   OUT STD_LOGIC;
+        man2_out:   OUT STD_LOGIC
     );
+    
 END main;
 
 
@@ -46,46 +46,128 @@ ARCHITECTURE monarch OF main IS
       );
     END COMPONENT;
 
-    SIGNAL global_reset_line : STD_LOGIC ;
+    COMPONENT clock_divider IS
+    PORT (
+        clock_100MHz : IN STD_lOGIC;
+        clock_50MHz : OUT STD_LOGIC ;
+        clock_1Hz : OUT STD_lOGIC
+    );
+    END COMPONENT ;
     
-    SIGNAL data_bus_line_for_randomgen:         STD_LOGIC_VECTOR(ascii_gen_bus_width-1 DOWNTO 0);    --allow 0 - 255 random numbers only
+    SIGNAL global_reset_line : STD_LOGIC ;
+    SIGNAL master_clock_line : STD_LOGIC ;
+    SIGNAL clock_50MHz_line : STD_LOGIC ;
+    SIGNAL clock_1Hz_line : STD_LOGIC ;
+    
+    SIGNAL data_bus_line_for_randomgen1:         STD_LOGIC_VECTOR(ascii_gen_bus_width-1 DOWNTO 0);    --allow 0 - 255 random numbers only
 
-    SIGNAL manchester_write_control :    STD_LOGIC := '0';
-    SIGNAL manchester_ready_for_data_on_din : STD_LOGIC;
-    SIGNAL data_bus_line_for_transmission:  STD_LOGIC_VECTOR(data_bus_width-1 DOWNTO 0);     
+    SIGNAL manchester1_write_control :    STD_LOGIC := '0' ;
+    SIGNAL manchester2_write_control :    STD_LOGIC := '0' ;
+    
+    SIGNAL manchester1_ready_for_data_on_din : STD_LOGIC ;
+    SIGNAL manchester2_ready_for_data_on_din : STD_LOGIC ;
+    
+    SIGNAL manchester1_overrun_error : STD_LOGIC ;
+    SIGNAL manchester2_overrun_error : STD_LOGIC ;
+    
+    SIGNAL data_bus_line_for_man1_transmission:  STD_LOGIC_VECTOR(data_bus_width-1 DOWNTO 0);
+    SIGNAL data_bus_line_for_man2_transmission:  STD_LOGIC_VECTOR(data_bus_width-1 DOWNTO 0);     
+
+    SIGNAL main_data_bus_line_for_all : STD_LOGIC_VECTOR(31 DOWNTO 0) := "01010101010101010100111010101011" ; --arbitrary number
+    
+    SIGNAL data_bus_for_asciigen : STD_LOGIC_VECTOR(ascii_gen_bus_width-1 DOWNTO 0) ;
+    
+    TYPE BYTESEL IS (ZERO, ONE, TWO, THREE) ;
+    SIGNAL BYTE : BYTESEL := ZERO ;
 
 BEGIN
 
-    global_reset_line <= reset ;
-    data_bus_line_for_transmission(data_bus_width-1 DOWNTO ascii_gen_bus_width) <= "00000000";
-
-    PROCESS(clock)  --Continuous transmission so long as encoder is ready ;
+CLOCK_SELECT:    PROCESS(master_clock_line, clock_50MHz_line, clock_1Hz_line)
     BEGIN
-        IF (manchester_ready_for_data_on_din='1') THEN
-            manchester_write_control <= '1' ;
-            data_bus_line_for_transmission(ascii_gen_bus_width-1 DOWNTO 0) <= data_bus_line_for_randomgen ;
+        IF clock_sel = '1' THEN
+            master_clock_line <= clock_50MHz_line ;
         ELSE
-            manchester_write_control <= '0' ;
+            master_clock_line <= clock_1Hz_line ;
+        END IF ;
+    END PROCESS ;
+      
+TRANSMISSION1:    PROCESS(master_clock_line, main_data_bus_line_for_all)
+    BEGIN
+        IF RISING_EDGE(master_clock_line) THEN
+            IF manchester1_ready_for_data_on_din = '1' AND manchester1_overrun_error = '0' THEN
+                manchester1_write_control <= '1' ; 
+                data_bus_line_for_man1_transmission <= main_data_bus_line_for_all(31 DOWNTO 16) ;
+            ELSE
+                manchester1_write_control <= '0' ;
+            END IF ;
         END IF ;
     END PROCESS ;
 
+TRANSMISSION2:  PROCESS(master_clock_line, main_data_bus_line_for_all)
+    BEGIN
+        IF RISING_EDGE(master_clock_line) THEN
+            IF manchester2_ready_for_data_on_din = '1' AND manchester2_overrun_error = '0' THEN
+                manchester2_write_control <= '1' ; 
+                data_bus_line_for_man2_transmission <= main_data_bus_line_for_all(15 DOWNTO 0) ;
+            ELSE
+                manchester2_write_control <= '0' ;
+            END IF ;
+        END IF ;
+    END PROCESS ;   
+
+DATABUS_LOADING: PROCESS (master_clock_line, data_bus_for_asciigen)
+    BEGIN
+        IF RISING_EDGE(master_clock_line) THEN
+            CASE BYTE IS
+                WHEN ZERO =>
+                    main_data_bus_line_for_all(7 DOWNTO 0) <= data_bus_for_asciigen;
+                    BYTE <= ONE ;
+                WHEN ONE =>
+                    main_data_bus_line_for_all(15 DOWNTO 8) <= data_bus_for_asciigen;
+                    BYTE <= TWO ;  
+                WHEN TWO =>
+                    main_data_bus_line_for_all(23 DOWNTO 16) <= data_bus_for_asciigen;
+                    BYTE <= THREE ;
+                WHEN THREE =>
+                    main_data_bus_line_for_all(31 DOWNTO 24) <= data_bus_for_asciigen;
+                    BYTE <= ZERO ;
+            END CASE ;
+        END IF ;
+    END PROCESS;
+      
+    
 -------------------------------------------------------------------------------------------------------
 -------------------------------------  PORT MAPS ------------------------------------------------------
 -------------------------------------------------------------------------------------------------------
 
+CLOCKDIV: clock_divider
+PORT MAP (clock_100MHz => clock, clock_50MHz => clock_50MHz_line, clock_1Hz => clock_1Hz_line) ;
+
 DATASRC: ascii_gen
 GENERIC MAP ( data_bus_width => ascii_gen_bus_width )
-PORT MAP (rand=>data_bus_line_for_randomgen, clock=>clock) ;
+PORT MAP (rand=>data_bus_for_asciigen, clock=>master_clock_line) ;
 
-MANENCODE: encode
+
+MANENCODE1: encode
 PORT MAP (
-    clk16x=>clock,
-    srst=>global_reset_line,
-    tx_data=>data_bus_line_for_transmission,
-    tx_stb=>manchester_write_control,
-    txd=>man_out,
-    or_err=>OPEN,
-    tx_idle=>manchester_ready_for_data_on_din
-) ;
+    clk16x=>master_clock_line,
+    srst=>reset,
+    tx_data=>data_bus_line_for_man1_transmission,
+    tx_stb=>manchester1_write_control,
+    txd=>man1_out,
+    or_err=> manchester1_overrun_error,
+    tx_idle=>manchester1_ready_for_data_on_din
+);
+
+MANENCODE2: encode
+PORT MAP (
+    clk16x=>master_clock_line,
+    srst=>reset,
+    tx_data=>data_bus_line_for_man2_transmission,
+    tx_stb=>manchester2_write_control,
+    txd=>man2_out,
+    or_err=> manchester2_overrun_error,
+    tx_idle=>manchester2_ready_for_data_on_din
+);
 
 END monarch;


### PR DESCRIPTION
Reduced the master clock to 50 MHz because of response observed on oscilliscope.
Using two Manchester which can be justified.