### PR TITLE
Transmit clean

### DIFF
--- a/clock_divider.vhd
+++ b/clock_divider.vhd
@@ -7,7 +7,7 @@ ENTITY clock_divider IS
     PORT (
         clock_100MHz    :   IN STD_lOGIC;
         clock_10MHz : OUT STD_LOGIC ;
-        clock_10kHz : OUT STD_LOGIC ;
+        clock_70kHz : OUT STD_LOGIC ;
         clock_1Hz:   OUT STD_lOGIC
     );
 END clock_divider;
@@ -15,11 +15,11 @@ END clock_divider;
 
 ARCHITECTURE clock_architecture OF clock_divider IS
     SIGNAL line_1Hz :   STD_LOGIC := '0' ;
-    SIGNAL line_10kHz : STD_LOGIC := '0' ;
+    SIGNAL line_70kHz : STD_LOGIC := '0' ;
     SIGNAL line_10MHz : STD_LOGIC := '0' ;
 BEGIN
     clock_1Hz <= line_1Hz ;
-    clock_10kHz <= line_10kHz ;
+    clock_70kHz <= line_70kHz ;
     clock_10MHz <= line_10MHz ;
    
     
@@ -36,23 +36,23 @@ FREQ_1Hz:       PROCESS(clock_100MHz)
         END IF;
     END PROCESS;
 
-FREQ_10kHz: PROCESS(clock_100MHz)
-        VARIABLE count_10_000 : INTEGER RANGE 0 TO 2 := 2 ; -- 0 to 1 DEC 
-        VARIABLE counter_10_000 : INTEGER RANGE 0 TO 2 := 0 ;   
+FREQ_70kHz: PROCESS(clock_100MHz)
+        VARIABLE count_70_000 : INTEGER RANGE 0 TO 715 := 715 ; -- 100MHz div. 70kHz ~~ 1420
+        VARIABLE counter_70_000 : INTEGER RANGE 0 TO 715 := 0 ;   
     BEGIN
         IF (clock_100MHz'EVENT AND clock_100MHz='1') THEN
-            IF (counter_10_000 = (count_10_000 - 1)) THEN
-                line_10kHz <= not line_10kHz ;
-                counter_10_000 := 0 ;
+            IF (counter_70_000 = (count_70_000 - 1)) THEN
+                line_70kHz <= not line_70kHz ;
+                counter_70_000 := 0 ;
             END IF ;
-            counter_10_000 := counter_10_000 + 1 ;
+            counter_70_000 := counter_70_000 + 1 ;
         END IF ;
     END PROCESS ;
     
-    
-FREQ_10MHz: PROCESS(clock_100MHz)
-            VARIABLE count_10_000_000 : INTEGER RANGE 0 TO 10 := 9 ; -- 0 to 9 DEC
-            VARIABLE counter_10_000_000 : INTEGER RANGE 0 TO 10 := 0 ;   
+    -- Clock for something around (not accurate) 1.3615MHz. The manchester encoder used requires an input clock of 19.45 * output data clock 
+FREQ_1p3615MHz: PROCESS(clock_100MHz)
+            VARIABLE count_10_000_000 : INTEGER RANGE 0 TO 45 := 45 ; -- 0 to 9 DEC 73 dev. 2 ~~ 36, but using 45
+            VARIABLE counter_10_000_000 : INTEGER RANGE 0 TO 45 := 0 ;   
         BEGIN
             IF (clock_100MHz'EVENT AND clock_100MHz='1') THEN
                 IF (counter_10_000_000 = (count_10_000_000 - 1)) THEN

--- a/clock_divider.vhd
+++ b/clock_divider.vhd
@@ -6,8 +6,8 @@ USE IEEE.NUMERIC_STD.ALL;
 ENTITY clock_divider IS
     PORT (
         clock_100MHz    :   IN STD_lOGIC;
-        clock_50MHz : OUT STD_LOGIC ;
         clock_10MHz : OUT STD_LOGIC ;
+        clock_10kHz : OUT STD_LOGIC ;
         clock_1Hz:   OUT STD_lOGIC
     );
 END clock_divider;
@@ -15,11 +15,11 @@ END clock_divider;
 
 ARCHITECTURE clock_architecture OF clock_divider IS
     SIGNAL line_1Hz :   STD_LOGIC := '0' ;
-    SIGNAL line_50MHz : STD_LOGIC := '0' ;
+    SIGNAL line_10kHz : STD_LOGIC := '0' ;
     SIGNAL line_10MHz : STD_LOGIC := '0' ;
 BEGIN
     clock_1Hz <= line_1Hz ;
-    clock_50MHz <= line_50MHz ;
+    clock_10kHz <= line_10kHz ;
     clock_10MHz <= line_10MHz ;
    
     
@@ -36,17 +36,16 @@ FREQ_1Hz:       PROCESS(clock_100MHz)
         END IF;
     END PROCESS;
 
-
-FREQ_50MHz: PROCESS(clock_100MHz)
-        VARIABLE count_50000000 : INTEGER RANGE 0 TO 2 := 2 ; -- 0 to 1 DEC 
-        VARIABLE counter_50000000 : INTEGER RANGE 0 TO 2 := 0 ;   
+FREQ_10kHz: PROCESS(clock_100MHz)
+        VARIABLE count_10_000 : INTEGER RANGE 0 TO 2 := 2 ; -- 0 to 1 DEC 
+        VARIABLE counter_10_000 : INTEGER RANGE 0 TO 2 := 0 ;   
     BEGIN
         IF (clock_100MHz'EVENT AND clock_100MHz='1') THEN
-            IF (counter_50000000 = (count_50000000 - 1)) THEN
-                line_50MHz <= not line_50MHz ;
-                counter_50000000 := 0 ;
+            IF (counter_10_000 = (count_10_000 - 1)) THEN
+                line_10kHz <= not line_10kHz ;
+                counter_10_000 := 0 ;
             END IF ;
-            counter_50000000 := counter_50000000 + 1 ;
+            counter_10_000 := counter_10_000 + 1 ;
         END IF ;
     END PROCESS ;
     

--- a/manchester_main.vhd
+++ b/manchester_main.vhd
@@ -61,17 +61,17 @@ ARCHITECTURE monarch OF main IS
     COMPONENT clock_divider IS
     PORT (
         clock_100MHz : IN STD_lOGIC;
-        clock_50MHz : OUT STD_LOGIC ;
         clock_10MHz : OUT STD_LOGIC ;
+        clock_10kHz : OUT STD_LOGIC ;
         clock_1Hz : OUT STD_lOGIC
     );
     END COMPONENT ;
     
     SIGNAL global_reset_line : STD_LOGIC := '0' ;
-    SIGNAL idle_line : STD_LOGIC := '1' ;
     SIGNAL init_line : STD_LOGIC := '0' ;
     
     SIGNAL clock_10MHz_line : STD_LOGIC ;
+    SIGNAL clock_10kHz_line : STD_LOGIC ;
     
     SIGNAL manchester_begin_transmission : STD_LOGIC := '0' ;
     
@@ -120,6 +120,7 @@ MAIN: PROCESS(clock, reset)
             srom_querry <= '0' ;
             manchester_begin_transmission <= '0' ;
             global_reset_line <= '1' ;
+            led_idle <= '0' ;
             init_line <= '1' ;
             txaction <= "000" ;
             
@@ -177,7 +178,9 @@ MAIN: PROCESS(clock, reset)
                     led_idle <= '1' ; 
                                      
             END CASE;
+            
         END IF;
+        
     END PROCESS;          
 
 
@@ -188,8 +191,8 @@ MAIN: PROCESS(clock, reset)
 CLOCKDIV: clock_divider
 PORT MAP (
     clock_100MHz => clock,
-    clock_50MHz => OPEN,
     clock_10MHz => clock_10MHz_line,
+    clock_10kHz => clock_10kHz_line, 
     clock_1Hz => OPEN
 );
 
@@ -206,7 +209,7 @@ PORT MAP (
 
 MANENCODE1: encode
 PORT MAP (
-    clk16x => clock,
+    clk16x => clock_10kHz_line,
     srst => global_reset_line,
     tx_data => data_bus_line_for_man1_transmission,
     tx_stb => manchester_begin_transmission,
@@ -217,7 +220,7 @@ PORT MAP (
 
 MANENCODE2: encode
 PORT MAP (
-    clk16x => clock,
+    clk16x => clock_10kHz_line,
     srst => global_reset_line,
     tx_data => data_bus_line_for_man2_transmission,
     tx_stb => manchester_begin_transmission,

--- a/transmitter_test_tb.vhd
+++ b/transmitter_test_tb.vhd
@@ -11,7 +11,7 @@ END monarch_tb;
 architecture tb of monarch_tb is
     SIGNAL start_tx, reset : STD_LOGIC ;  --inputs
     SIGNAL clock : STD_LOGIC := '0' ;  --inputs
-    SIGNAL man1_out, man2_out, led_idle : STD_LOGIC ;  --outputs   
+    SIGNAL man1_out, man2_out, led_idle, tx_mode : STD_LOGIC ;  --outputs   
     SIGNAL test_tout : STD_LOGIC_VECTOR(31 DOWNTO 0) ;
     
     SIGNAL test_man1 : STD_LOGIC;
@@ -27,15 +27,17 @@ begin
         test_man2 => test_man2, 
         test_querry => test_querry,
         led_idle => led_idle,
+        tx_mode => tx_mode,
         test_manbeg => test_manbeg 
     );
     
+    tx_Mode <= '0' after 5 ns, '1' after 10 ns ;
     start_tx <= '1' after 100 ns ;
     reset <= '0' after 50 ns ;
 
     CLK: PROCESS
     BEGIN
-        FOR i IN 0 TO 700_000_000 LOOP
+        FOR i IN 0 TO 10_000_000 LOOP
             clock <= not clock ;
             wait for 10 ns ;
         END LOOP;

--- a/transmitter_test_tb.vhd
+++ b/transmitter_test_tb.vhd
@@ -31,13 +31,13 @@ begin
         test_manbeg => test_manbeg 
     );
     
-    tx_Mode <= '0' after 5 ns, '1' after 10 ns ;
-    start_tx <= '1' after 100 ns ;
-    reset <= '0' after 50 ns ;
+    tx_mode <= '0' after 10 ns, '1' after 1_000_000 ns ;
+    start_tx <= '1' after 10 ns, '0' after 1_000_000 ns ; 
+    reset <= '0' after 10 ns, '1' after 1_000_000 ns, '0' after 1_000_010 ns ;
 
     CLK: PROCESS
     BEGIN
-        FOR i IN 0 TO 10_000_000 LOOP
+        FOR i IN 0 TO 100_000_000 LOOP
             clock <= not clock ;
             wait for 10 ns ;
         END LOOP;


### PR DESCRIPTION
I figured for a given clock input to the Manchester encoder, the output clock rate is approx. divided by 19.45 . To account for this, the Manchester input clock is about 1.3MHz. This is not accurate as I made coarse adjustments to obtain a suitable response on the oscilloscope i.e. square waves without roll-off at edges.

The FPGA has a 3.3V logic and I needed to drive a 5V circuit. A 2N2222 (NPN transistor) was added at the FPGA output to account for this; hence, the inversion of the manchester output.

Refractoring will take place later as it is not important to do at this time.